### PR TITLE
Fix types export

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,2 @@
 export * from './supabase';
-export * from './scores';
 export * from './auth';


### PR DESCRIPTION
## Summary
- remove obsolete scores export from types

## Testing
- `npm install`
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847a0ac5d20832ba9268396917172d3