### PR TITLE
Add basic supabase utility test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node test/test-supabase.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^4.1.3",
@@ -39,6 +40,9 @@
     "eslint-config-next": "15.2.3",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.3.4",
+    "@types/jest": "^29.5.14"
   }
 }

--- a/test/test-supabase.js
+++ b/test/test-supabase.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const tsPath = join(__dirname, '../src/lib/utils.ts');
+let code = readFileSync(tsPath, 'utf8');
+code = code.replace(/import[^;]+;/g, '');
+code = code.replace(/: [A-Za-z0-9_<>,\[\]| ]+/g, '');
+code = code.replace(/export /g, '');
+code += '\nmodule.exports = { formatCurrency };';
+const module = { exports: {} };
+new Function('module', code)(module);
+const { formatCurrency } = module.exports;
+
+test('formatCurrency formats numbers as USD', () => {
+  assert.strictEqual(formatCurrency(1234.56), '$1,234.56');
+});


### PR DESCRIPTION
## Summary
- add a Node test that dynamically loads `formatCurrency` from `utils.ts`
- expose a `npm test` script to run the Node test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847a0b01240832bb72569319a98181a